### PR TITLE
fix bug in create_env_list

### DIFF
--- a/builtins/env_utils.c
+++ b/builtins/env_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   env_utils.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: danisanc <danisanc@student.42.fr>          +#+  +:+       +#+        */
+/*   By: vangirov <vangirov@student.42wolfsburg.    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/07/11 18:58:38 by danisanc          #+#    #+#             */
-/*   Updated: 2022/08/21 11:48:43 by danisanc         ###   ########.fr       */
+/*   Updated: 2022/08/24 08:00:44 by vangirov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,6 +34,7 @@ char	**list_to_arr(t_env **env_list)
 	return (new_arr);
 }
 
+
 t_env	*create_env_list(char	**envp)
 {
 	t_env	*env_list;
@@ -46,8 +47,10 @@ t_env	*create_env_list(char	**envp)
 	{
 		if (envp[i][ft_strlen(envp[i]) - 1] == '=')
 		{
-			array[0] = ft_strdup(envp[i]);
-			array[1] = "";
+			array = malloc(sizeof(char *) * 2);
+			array[0] = malloc(ft_strlen(envp[i]));
+			ft_strlcpy(array[0], envp[i], ft_strlen(envp[i]));
+			array[1] = ft_strdup("");
 		}
 		else
 			array = ft_split(envp[i], '=');

--- a/exec/exec_utils.c
+++ b/exec/exec_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec_utils.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: danisanc <danisanc@student.42.fr>          +#+  +:+       +#+        */
+/*   By: vangirov <vangirov@student.42wolfsburg.    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/07/13 20:39:27 by danisanc          #+#    #+#             */
-/*   Updated: 2022/08/23 19:59:09 by danisanc         ###   ########.fr       */
+/*   Updated: 2022/08/24 08:30:06 by vangirov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,11 +38,14 @@ void	if_redirs_or_null(t_group *group, t_msh *msh, int j)
 
 void	check_what_redirs(t_group *group, t_msh *msh, int j)
 {
-	while (group->cmds->redirs[j][0])
+	t_list*	link;
+
+	link = group->cmds->redirs[j][0];
+	while (link)
 	{
 		check_infile(group, msh, j);
 		check_outfile(group, j);
-		group->cmds->redirs[j][0] = group->cmds->redirs[j][0]->next;
+		link = link->next;
 	}
 }
 


### PR DESCRIPTION
If it deals with empty variables (no value), it causes segfault on some systems because it tries to write to an array which has not been allocated.